### PR TITLE
Adds missing spaces to cookiecutter LICENSE file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ indent_size = 4
 [Makefile]
 indent_style = tab
 indent_size = 1
+
+[LICENSE]
+indent_size = none

--- a/{{cookiecutter.module_name}}/.editorconfig
+++ b/{{cookiecutter.module_name}}/.editorconfig
@@ -18,3 +18,6 @@ indent_size = 4
 [Makefile]
 indent_style = tab
 indent_size = 1
+
+[LICENSE]
+indent_size = none

--- a/{{cookiecutter.module_name}}/LICENSE
+++ b/{{cookiecutter.module_name}}/LICENSE
@@ -1,10 +1,10 @@
-                                Apache License
-                          Version 2.0, January 2004
+                                 Apache License
+                           Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
-  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-  1. Definitions.
+   1. Definitions.
 
       "License" shall mean the terms and conditions for use, reproduction,
       and distribution as defined by Sections 1 through 9 of this document.
@@ -63,14 +63,14 @@
       on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
-  2. Grant of Copyright License. Subject to the terms and conditions of
+   2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       copyright license to reproduce, prepare Derivative Works of,
       publicly display, publicly perform, sublicense, and distribute the
       Work and such Derivative Works in Source or Object form.
 
-  3. Grant of Patent License. Subject to the terms and conditions of
+   3. Grant of Patent License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       (except as stated in this section) patent license to make, have made,
@@ -86,7 +86,7 @@
       granted to You under this License for that Work shall terminate
       as of the date such litigation is filed.
 
-  4. Redistribution. You may reproduce and distribute copies of the
+   4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
@@ -127,7 +127,7 @@
       reproduction, and distribution of the Work otherwise complies with
       the conditions stated in this License.
 
-  5. Submission of Contributions. Unless You explicitly state otherwise,
+   5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
       by You to the Licensor shall be under the terms and conditions of
       this License, without any additional terms or conditions.
@@ -135,12 +135,12 @@
       the terms of any separate license agreement you may have executed
       with Licensor regarding such Contributions.
 
-  6. Trademarks. This License does not grant permission to use the trade
+   6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
       except as required for reasonable and customary use in describing the
       origin of the Work and reproducing the content of the NOTICE file.
 
-  7. Disclaimer of Warranty. Unless required by applicable law or
+   7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
       Contributor provides its Contributions) on an "AS IS" BASIS,
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
@@ -150,7 +150,7 @@
       appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
 
-  8. Limitation of Liability. In no event and under no legal theory,
+   8. Limitation of Liability. In no event and under no legal theory,
       whether in tort (including negligence), contract, or otherwise,
       unless required by applicable law (such as deliberate and grossly
       negligent acts) or agreed to in writing, shall any Contributor be
@@ -162,7 +162,7 @@
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
 
-  9. Accepting Warranty or Additional Liability. While redistributing
+   9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
       or other liability obligations and/or rights consistent with this
@@ -173,9 +173,9 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
-  END OF TERMS AND CONDITIONS
+   END OF TERMS AND CONDITIONS
 
-  APPENDIX: How to apply the Apache License to your work.
+   APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
       boilerplate notice, with the fields enclosed by brackets "[]"
@@ -186,16 +186,16 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-  Copyright {% now 'utc', '%Y' %} Maintainers of {{cookiecutter.github_username}}/{{cookiecutter.module_name}}
+   Copyright {% now 'utc', '%Y' %} Maintainers of {{cookiecutter.github_username}}/{{cookiecutter.module_name}}
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Issue was previously identified in [this](https://github.com/plus3it/terraform-aws-tardigrade-cloudtrail/pull/1/files#diff-9879d6db96fd29134fc802214163b95a) diff