### PR TITLE
Adds ability to auto approve and merge Dependabot PRs

### DIFF
--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -1,0 +1,12 @@
+name: auto approve dependabot pull requests
+on: pull_request
+
+jobs:
+  auto-approve-dependabot-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: auto approve dependabot pull requests
+        uses: hmarr/auto-approve-action@master
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+  - name: automatic merge for approved Dependabot pull requests
+    conditions:
+      - author~=dependabot\[bot\]|dependabot-preview\[bot\]
+      - status-success=Travis CI - Pull Request
+    actions:
+      merge:
+        method: merge

--- a/{{cookiecutter.module_name}}/.github/workflows/approve-dependabot-pr.yml
+++ b/{{cookiecutter.module_name}}/.github/workflows/approve-dependabot-pr.yml
@@ -1,0 +1,12 @@
+name: auto approve dependabot pull requests
+on: pull_request
+
+jobs:
+  auto-approve-dependabot-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: auto approve dependabot pull requests
+        uses: hmarr/auto-approve-action@master
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/{{cookiecutter.module_name}}/.mergify.yml
+++ b/{{cookiecutter.module_name}}/.mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+  - name: automatic merge for approved Dependabot pull requests
+    conditions:
+      - author~=dependabot\[bot\]|dependabot-preview\[bot\]
+      - status-success=Travis CI - Pull Request
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
This PR will add the ability to auto-approve and auto-merge pull requests created by Depenedabot.
Utilizing GitHub action to auto-approve and using Mergify.io to auto-merge the pull requests.

Configuration steps for GitHub Action:
* Signup for GitHub Actions Beta

Configuration steps for Mergify.io:
* Grant mergify access to the repo. This step is completed, but if it needs to be re-configured, you can access this [site](https://mergify.io/dashboard) to do so.