### PR TITLE
Terraform 0.12 fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 1.1.2
+
+**Commit Delta**: [Change from 1.1.1 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.1...1.1.2)
+
+**Released**: 2019.10.16
+
+**Summary**:
+
+*   Adjusts terraform workflow to support terraform 0.12
+
 ### 1.1.1
 
 **Commit Delta**: [Change from 1.1.0 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.0...1.1.1)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -76,9 +76,13 @@ def get_collaborators():
     return collaborators
 
 
-def run_terraform(directory, target_module):
+def run_terraform(directory, terraform_vars, target_module):
     terraform = Terraform(directory)
     terraform.init(from_module=target_module)
+
+    with open(directory + "terraform.tfvars.json", "w") as fh_:
+        fh_.write(json.dumps(terraform_vars))
+
     ret_code, stdout, stderr = (
         terraform.apply(
             auto_approve=True,
@@ -210,10 +214,7 @@ if __name__ == "__main__":
         if collaborators:
             terraform_vars['access_teams'] = collaborators
 
-        with open(directory + "terraform.tfvars.json", "w") as fh_:
-            fh_.write(json.dumps(terraform_vars))
-
-        run_terraform(directory, TF_MODULE_URL)
+        run_terraform(directory, terraform_vars,  TF_MODULE_URL)
 
         shutil.rmtree(os.path.join(os.getcwd(), directory))
         source_repo = (


### PR DESCRIPTION
Terraform 0.11 will happily init on a non-empty directory, Terraform 0.12 will not.