### PR TITLE
Removes personal repo reference from ci config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 SHELL := /bin/bash
 
--include $(shell curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/userhas404d/ci-testing/master/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)
+-include $(shell curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/plus3it/tardigrade-ci/master/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)


### PR DESCRIPTION
Pretty sure I was using this repo as the original testing target for tardgirade-ci and missed this until the recent CI failure.