### PR TITLE
Remove github readonly token from inputs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.6
+current_version = 1.1.7
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 1.1.7
+
+**Commit Delta**: [Change from 1.1.6 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.6...1.1.7)
+
+**Released**: 2020.04.08
+
+**Summary**:
+
+*   Remove github readonly token from cookiecutter inputs
+
+### 1.1.6
+
+**Commit Delta**: [Change from 1.1.5 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.5...1.1.6)
+
+**Released**: 2020.03.25
+
+**Summary**:
+
+*   Removes stale dependencies
+
 ### 1.1.5
 
-**Commit Delta**: [Change from 1.1.2 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.4...1.1.5)
+**Commit Delta**: [Change from 1.1.4 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.4...1.1.5)
 
 **Released**: 2020.1.29
 
@@ -16,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### 1.1.4
 
-**Commit Delta**: [Change from 1.1.2 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.3...1.1.4)
+**Commit Delta**: [Change from 1.1.3 release](https://github.com/plus3it/cookiecutter-tfmodule/compare/1.1.3...1.1.4)
 
 **Released**: 2020.1.29
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ You will be asked for these fields:
 | ------------------ | ------- | ----------- |
 | ``create_repo`` | ``no`` | Whether or not to automatically create a repo on GitHub. |
 | ``create_org_repo`` | ``no`` | Whether or not to automatically create an organizational repo on GitHub. |
-| ``github_readonly_token`` | ``null`` | GitHub OATH Token to make informational API calls. |
 | ``github_releases_token`` | ``null`` | GitHub OATH Token used to automatically tag repo on a pull request approval. |
 | ``github_username`` | ``plus3it`` | Your GitHub Username. |
 | ``module_name`` | ``template`` | The name of the terraform module that you are creating. |

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,6 @@
     ],
     "create_org_repo": "no",
     "create_repo": "no",
-    "github_readonly_token": "",
     "github_releases_token": "",
     "github_username": "plus3it",
     "module_name": "template",


### PR DESCRIPTION
All references to the readonly token has been removed due to the use of tardigrade-ci so we no longer need to ask for a token as part of the cookiecutter inputs.